### PR TITLE
Update releases.properties from release 2025.11.23

### DIFF
--- a/releases.properties
+++ b/releases.properties
@@ -1,4 +1,4 @@
-3.4.7-2025 = https://github.com/Bearsampp/module-ruby/releases/download/2025.11.23/bearsampp-ruby-3.4.7-2025.11.23.7z
+3.4.7 = https://github.com/Bearsampp/module-ruby/releases/download/2025.11.23/bearsampp-ruby-3.4.7-2025.11.23.7z
 3.4.5 = https://github.com/Bearsampp/module-ruby/releases/download/2025.8.16/bearsampp-ruby-3.4.5-2025.8.16.7z
 3.4.4-2 = https://github.com/Bearsampp/module-ruby/releases/download/2025.7.2/bearsampp-ruby-3.4.4-2-2025.7.2.7z
 3.4.3 = https://github.com/Bearsampp/module-ruby/releases/download/2025.4.19/bearsampp-ruby-3.4.3-2025.4.19.7z


### PR DESCRIPTION
### **User description**
## 🤖 Automated Releases Properties Update

This PR updates the `releases.properties` file with new versions from release `2025.11.23`.

### Changes:
- Extracted .7z assets from the release
- Added version entries with download URLs
- Maintained semver ordering (newest first)

**Release URL:** https://github.com/Bearsampp/module-ruby/releases/tag/2025.11.23

### Next Steps:
1. ⏳ Link validation will run automatically
2. ✅ Once validation passes, this PR will auto-merge
3. ❌ If validation fails, please review and fix invalid URLs


___

### **PR Type**
Enhancement


___

### **Description**
- Updates Ruby version entry from 3.4.7-2025 to 3.4.7

- Maintains download URL for release 2025.11.23

- Simplifies version naming convention


___

### Diagram Walkthrough


```mermaid
flowchart LR
  old["3.4.7-2025"] -- "renamed to" --> new["3.4.7"]
  new -- "points to" --> url["Release 2025.11.23"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>releases.properties</strong><dd><code>Simplify Ruby version naming convention</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

releases.properties

<ul><li>Changed version key from <code>3.4.7-2025</code> to <code>3.4.7</code><br> <li> Maintained the same download URL for release 2025.11.23<br> <li> Simplified version naming by removing date suffix</ul>


</details>


  </td>
  <td><a href="https://github.com/Bearsampp/module-ruby/pull/18/files#diff-e6bca46c0571eef762f6438540dd9012a0432e7055b4805f2fed16ecd993b645">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

